### PR TITLE
Issue #15: fix Appetize guard parsing

### DIFF
--- a/.github/workflows/ios-simulator-build.yml
+++ b/.github/workflows/ios-simulator-build.yml
@@ -41,11 +41,14 @@ jobs:
           path: HotTubLog-simulator.app.zip
 
       - name: Upload to Appetize (optional)
-        if: ${{ secrets.APPETIZE_API_TOKEN != '' && secrets.APPETIZE_APP_PUBLIC_KEY != '' }}
         env:
           APPETIZE_API_TOKEN: ${{ secrets.APPETIZE_API_TOKEN }}
           APPETIZE_APP_PUBLIC_KEY: ${{ secrets.APPETIZE_APP_PUBLIC_KEY }}
         run: |
+          if [ -z "${APPETIZE_API_TOKEN}" ] || [ -z "${APPETIZE_APP_PUBLIC_KEY}" ]; then
+            echo "Skipping Appetize upload (missing secrets)."
+            exit 0
+          fi
           curl -X POST "https://api.appetize.io/v1/apps/${APPETIZE_APP_PUBLIC_KEY}" \
             -H "X-API-KEY: ${APPETIZE_API_TOKEN}" \
             -F "file=@HotTubLog-simulator.app.zip" \


### PR DESCRIPTION
Closes #15.

Moves the Appetize secrets check into the script so the workflow parses for preview runs.