### PR TITLE
Issue #19: fix AddEntryView photo removal

### DIFF
--- a/HotTubLog/Views/AddEntryView.swift
+++ b/HotTubLog/Views/AddEntryView.swift
@@ -113,14 +113,14 @@ struct AddEntryView: View {
 
     private var photoField: some View {
         Section("Photo") {
-            if let photoImage {
-                Image(uiImage: photoImage)
+            if let image = photoImage {
+                Image(uiImage: image)
                     .resizable()
                     .scaledToFit()
                     .frame(maxHeight: 220)
 
                 Button("Remove Photo") {
-                    photoImage = nil
+                    self.photoImage = nil
                     selectedPhotoItem = nil
                     photoUpdated = true
                 }


### PR DESCRIPTION
Closes #19.

Avoids shadowed optional binding so the photo can be cleared in the add/edit form.