### PR TITLE
Issue #27: use generic simulator destination

### DIFF
--- a/.github/workflows/ios-simulator-build.yml
+++ b/.github/workflows/ios-simulator-build.yml
@@ -26,7 +26,7 @@ jobs:
             -scheme HotTubLog \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath build \
             CODE_SIGNING_ALLOWED=NO
 


### PR DESCRIPTION
Closes #27.

Avoids hard-coded simulator device name in CI.